### PR TITLE
EMR Cluster Manager Improvements (different strategies to share a cluster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 .settings/
 .idea/
 *.iml
+*.ipr
+*.iws
 /bin
 .classpath
 .project

--- a/azkaban-execserver/src/main/java/azkaban/execapp/cluster/EmrClusterManager.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/cluster/EmrClusterManager.java
@@ -251,7 +251,7 @@ public class EmrClusterManager implements IClusterManager, EventListener {
 
         switch (executionMode) {
             case CREATE_CLUSTER:
-                maybeTerminateEphemoralCluster(flow, combinedProps, jobLogger);
+                maybeTerminateEphemeralCluster(flow, combinedProps, jobLogger);
                 break;
 
             default:
@@ -268,7 +268,7 @@ public class EmrClusterManager implements IClusterManager, EventListener {
      * @param combinedProps
      * @param jobLogger
      */
-    private synchronized void maybeTerminateEphemoralCluster(ExecutableFlow flow, Props combinedProps, Logger jobLogger) {
+    private synchronized void maybeTerminateEphemeralCluster(ExecutableFlow flow, Props combinedProps, Logger jobLogger) {
         // Is this flow only ok to shutdown the cluster?
         boolean okThisFlowToShutdown = shouldShutdown(combinedProps, flow.getStatus(), jobLogger);
 
@@ -431,18 +431,7 @@ public class EmrClusterManager implements IClusterManager, EventListener {
     }
 
     private enum ClusterNameStrategy {
-        EXECUTION_ID(false),
-        PROJECT_NAME(true);
-
-        private boolean supportClusterWithMultipleFlows;
-
-        private ClusterNameStrategy(boolean c) {
-            supportClusterWithMultipleFlows = c;
-        }
-
-        public boolean doesSupportClusterWithMultipleFlows() {
-            return supportClusterWithMultipleFlows;
-        }
-
+        EXECUTION_ID,
+        PROJECT_NAME;
     }
 }

--- a/azkaban-execserver/src/main/java/azkaban/execapp/cluster/EmrClusterManager.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/cluster/EmrClusterManager.java
@@ -46,7 +46,7 @@ public class EmrClusterManager implements IClusterManager, EventListener {
     // Cluster Name -> Integer (Count of flows using cluster) - only going into shutdown process for emr clusters when all executions that use the cluster are done
     private Map<String, Integer> clusterFlows = new ConcurrentHashMap<String, Integer>();
 
-    // (Item is Cluster Name) - List of clusters to keep alive - when multiple flows share the same cluster, if any of the flows indicate that the cluster should not be shutdown (because of an error or any other reason), the cluster should not be terminated even if it's ok to be terminated by the other flows using it.
+    // (Item is Cluster Id) - List of clusters to keep alive - when multiple flows share the same cluster, if any of the flows indicate that the cluster should not be shutdown (because of an error or any other reason), the cluster should not be terminated even if it's ok to be terminated by the other flows using it.
     private List<String> clustersKeepAlive = Collections.synchronizedList(new ArrayList<String>());
 
     public EmrClusterManager(Props serverProps) {

--- a/azkaban-execserver/src/main/java/azkaban/execapp/cluster/EmrClusterManager.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/cluster/EmrClusterManager.java
@@ -270,7 +270,7 @@ public class EmrClusterManager implements IClusterManager, EventListener {
      */
     private synchronized void maybeTerminateEphemeralCluster(ExecutableFlow flow, Props combinedProps, Logger jobLogger) {
         // Is this flow only ok to shutdown the cluster?
-        boolean okThisFlowToShutdown = shouldShutdown(combinedProps, flow.getStatus(), jobLogger);
+        boolean okForThisFlowToShutdownCluster = shouldShutdown(combinedProps, flow.getStatus(), jobLogger);
 
         // Flow Properties
         Status flowStatus = flow.getStatus();
@@ -293,18 +293,18 @@ public class EmrClusterManager implements IClusterManager, EventListener {
         Boolean otherFlowsOkToShutdown = !clustersKeepAlive.contains(clusterName);
 
         // Log Debug
-        jobLogger.info("Maybe Shutdown - Flow Status: " + flowStatus);
-        jobLogger.info("Maybe Shutdown - Cluster Id: " + clusterId);
-        jobLogger.info("Maybe Shutdown - Cluster Name: " + clusterName);
-        jobLogger.info("Maybe Shutdown - Latch Count: " + count);
-        jobLogger.info("Maybe Shutdown - Is ok with this flow to shutdown cluster: " + okThisFlowToShutdown);
+        jobLogger.info("Shutdown Process - Flow Status: " + flowStatus);
+        jobLogger.info("Shutdown Process - Cluster Id: " + clusterId);
+        jobLogger.info("Shutdown Process - Cluster Name: " + clusterName);
+        jobLogger.info("Shutdown Process - Latch Count: " + count);
+        jobLogger.info("Shutdown Process - Is ok with this flow to shutdown cluster: " + okForThisFlowToShutdownCluster);
 
         // If this is the last flow using the cluster
         if (count == 0 || count == null) {
-            jobLogger.info("Maybe Shutdown - Is ok with the other flows sharing this cluster to shutdown the cluster: " + otherFlowsOkToShutdown);
+            jobLogger.info("Shutdown Process - Is ok with the other flows sharing this cluster to shutdown the cluster: " + otherFlowsOkToShutdown);
 
             try {
-                if (okThisFlowToShutdown && otherFlowsOkToShutdown) {
+                if (okForThisFlowToShutdownCluster && otherFlowsOkToShutdown) {
                     if (clusterId != null) {
                         jobLogger.info("Terminating cluster " + clusterId);
                         terminateCluster(getEmrClient(), clusterId);
@@ -320,7 +320,7 @@ public class EmrClusterManager implements IClusterManager, EventListener {
                 clusterFlows.remove(clusterName);
             }
 
-        } else if (!okThisFlowToShutdown) {
+        } else if (!okForThisFlowToShutdownCluster) {
             // If we are not shutting down the cluster now and it's not ok for the cluster to be shutdown from this specific flow's prespective, add note to that
             clustersKeepAlive.add(clusterName);
         }


### PR DESCRIPTION
* Adding new configuration property to allow clusters to be shared by execution id or by project name
* If a cluster is shared by project name, more than one flow can use the cluster, so it can only terminate when all the flows are done (and all flows are ok to shutdown the cluster)