### PR TITLE
bump headerBufferSize 

### DIFF
--- a/azkaban-execserver/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -75,7 +75,7 @@ public class AzkabanExecutorServer {
   public static final String METRIC_INTERVAL =
       "executor.metric.milisecinterval.";
   public static final int DEFAULT_PORT_NUMBER = 12321;
-  public static final int DEFAULT_HEADER_BUFFER_SIZE = 4096;
+  public static final int DEFAULT_HEADER_BUFFER_SIZE = 10 * 1024 * 1024;
 
   private static final String DEFAULT_TIMEZONE_ID = "default.timezone.id";
   private static final int DEFAULT_THREAD_NUMBER = 50;

--- a/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -676,7 +676,8 @@ public class AzkabanWebServer extends AzkabanServer {
           .getString("jetty.truststore"));
       secureConnector.setTrustPassword(azkabanSettings
           .getString("jetty.trustpassword"));
-      secureConnector.setHeaderBufferSize(MAX_HEADER_BUFFER_SIZE);
+      secureConnector.setHeaderBufferSize(azkabanSettings
+              .getInt("jetty.headerBufferSize", MAX_HEADER_BUFFER_SIZE));
 
       // set up vulnerable cipher suites to exclude
       List<String> cipherSuitesToExclude = azkabanSettings.getStringList("jetty.excludeCipherSuites");
@@ -691,7 +692,8 @@ public class AzkabanWebServer extends AzkabanServer {
       port = azkabanSettings.getInt("jetty.port", DEFAULT_PORT_NUMBER);
       SocketConnector connector = new SocketConnector();
       connector.setPort(port);
-      connector.setHeaderBufferSize(MAX_HEADER_BUFFER_SIZE);
+      connector.setHeaderBufferSize(azkabanSettings
+              .getInt("jetty.headerBufferSize", MAX_HEADER_BUFFER_SIZE));
       server.addConnector(connector);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.0.39
+version=3.0.40
 group=com.salesforceiq.azkaban


### PR DESCRIPTION
headerBufferSize is another potential culprit to produce the same error. It is already passed in as jetty.headerBufferSize on executor server but default is tiny. Change on web server and bump default on executor server