### PR TITLE
IQC-1818  

### DIFF
--- a/azkaban-execserver/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -381,7 +381,7 @@ public class FlowRunnerManager implements EventListener,
           if (exDir.lastModified() < fullCleanupThreshold) {
             FileUtils.deleteDirectory(exDir);
           } else {
-            for (File file : exDir.listFiles()) {
+            for (File file : FileUtils.listFiles(exDir, null, true)) {
               if (Files.isSymbolicLink(file.toPath())) {
                 FileUtils.deleteDirectory(file);
               }


### PR DESCRIPTION
Reopen issue https://jira.salesforceiq.com/browse/IQC-1818

Found on dev the old execution directories are not cleaned up since we are only checking symbolic links at first level. Perform the check recursively now.